### PR TITLE
chore: use Visual Studio 2017 in appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,3 +1,6 @@
+image:
+  - Visual Studio 2017
+
 environment:
   matrix:
     - nodejs_version: "18"


### PR DESCRIPTION
Instead of the default of Visual Studio 2015. This will fix the error:

```
Node.js is only supported on Windows 10, Windows Server 2016, or higher.
Setting the NODE_SKIP_PLATFORM_CHECK environment variable to 1 skips this
check, but Node.js might not execute correctly. Any issues encountered on
unsupported platforms will not be fixed.
```